### PR TITLE
Evolver: Set Vivo Green as default pressed state

### DIFF
--- a/res/xml/evolution_settings_lockscreen.xml
+++ b/res/xml/evolution_settings_lockscreen.xml
@@ -73,7 +73,7 @@
             android:summary="%s"
             android:entries="@array/fod_pressed_state_entries"
             android:entryValues="@array/fod_pressed_state_values"
-            android:defaultValue="0" />
+            android:defaultValue="6" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
It works the best for most devices.