### PR TITLE
Evolver: Set Vivo Green as default pressed state [2/2]

### DIFF
--- a/res/xml/evolution_settings_lockscreen.xml
+++ b/res/xml/evolution_settings_lockscreen.xml
@@ -73,7 +73,7 @@
             android:summary="%s"
             android:entries="@array/fod_pressed_state_entries"
             android:entryValues="@array/fod_pressed_state_values"
-            android:defaultValue="6" />
+            android:defaultValue="5" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Actually sets it as default instead of just being shown as the default.