### PR TITLE
SystemUI: Introduce Google TV remote controls keyguard affordance [1/2]

### DIFF
--- a/res/values/evolution_arrays.xml
+++ b/res/values/evolution_arrays.xml
@@ -840,6 +840,7 @@
         <item>@string/lockscreen_shortcut_flashlight</item>
         <item>@string/lockscreen_shortcut_qr</item>
         <item>@string/lockscreen_shortcut_camera</item>
+        <item>@string/lockscreen_shortcut_remote</item>
         <item>@string/lockscreen_shortcut_none</item>
     </string-array>
 
@@ -849,6 +850,7 @@
         <item>flashlight</item>
         <item>qr</item>
         <item>camera</item>
+        <item>remote</item>
         <item>none</item>
     </string-array>
 </resources>

--- a/res/values/evolution_strings.xml
+++ b/res/values/evolution_strings.xml
@@ -1154,6 +1154,7 @@
     <string name="lockscreen_shortcut_flashlight">Flashlight</string>
     <string name="lockscreen_shortcut_qr">QR</string>
     <string name="lockscreen_shortcut_camera">Camera</string>
+    <string name="lockscreen_shortcut_remote">Google TV Remote Controls</string>
     <string name="lockscreen_shortcut_none">None</string>
     <string name="lockscreen_shortcut_enforce_title">Single shortcut</string>
     <string name="lockscreen_shortcut_enforce_summary">Enforce chosen shortcut to be the only existing priority\nWill show nothing until the specific chosen shortcut is available</string>


### PR DESCRIPTION
This adds a button for launching the Remote controls from Google TV app at the bottom of the lockscreen for quick access.